### PR TITLE
feature/top-cards to be merged into development

### DIFF
--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -1,0 +1,11 @@
+const FINHUB_API_KEY = import.meta.env.VITE_FINHUB_API_KEY;
+
+export const getPercentageChange = async (symbol: string) => {
+  const API_ENDPOINT = "https://finnhub.io/api/v1";
+  const response = await fetch(
+    `${API_ENDPOINT}/quote?symbol=${symbol}&token=${FINHUB_API_KEY}`
+  );
+  const data = await response.json();
+
+  return data.dp ? data : null;
+};

--- a/src/components/cards/TopCard.tsx
+++ b/src/components/cards/TopCard.tsx
@@ -1,0 +1,83 @@
+import { Box, Typography } from "@mui/material";
+import { useState, useEffect } from "react";
+import { getPercentageChange } from "../../api/requests";
+
+interface TopCardProps {
+  stockName: string;
+  currentPrice: number;
+  alertPrice: number;
+}
+
+const TopCard = ({ stockName, currentPrice, alertPrice }: TopCardProps) => {
+  const [percentage, setPercentage] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchPercentageChange = async () => {
+      const data = await getPercentageChange(stockName);
+      const dp = data.dp;
+      console.log("Percentage Change", data.dp);
+      setPercentage(dp);
+    };
+
+    fetchPercentageChange();
+
+    const interval = setInterval(() => {
+      fetchPercentageChange();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [stockName]);
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid #ddd",
+        borderRadius: 4,
+        padding: 2,
+        backgroundColor: "#f9f9f9",
+        textAlign: "center",
+        marginBottom: 2,
+        boxShadow: "0 2px 4px rgba(0, 0, 0, 0.1)",
+      }}
+    >
+      <Typography variant="h6" gutterBottom>
+        {stockName}
+      </Typography>
+
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+        <Typography
+          variant="h4"
+          gutterBottom
+          color={
+            alertPrice === 0
+              ? "black"
+              : currentPrice > alertPrice
+              ? "green"
+              : "red"
+          }
+          sx={{ marginRight: 2 }}
+        >
+          ${currentPrice.toFixed(2)}
+        </Typography>
+
+        <Typography
+          variant="subtitle1"
+          sx={{
+            color: percentage !== null && percentage >= 0 ? "green" : "red",
+          }}
+        >
+          {percentage !== null ? (
+            <>
+              {percentage >= 0 ? "+" : ""}
+              {percentage.toFixed(2)}%
+            </>
+          ) : (
+            "N/A"
+          )}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default TopCard;

--- a/src/components/form/LeftForm.tsx
+++ b/src/components/form/LeftForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import TopCard from "../cards/TopCard";
 import {
   TextField,
   Button,
@@ -19,6 +20,7 @@ const LeftForm = () => {
 
   const handleWebSocketMessage = (data: any) => {
     if (data.type === "trade" && data.data) {
+      console.log("data", data);
       const trade = data.data[0];
       const price = trade.p; // Current Price
       setCurrentPrice(price);
@@ -47,6 +49,16 @@ const LeftForm = () => {
 
   return (
     <Box sx={{ width: "100%", maxWidth: 400, margin: "auto", padding: 3 }}>
+      <Box sx={{ marginBottom: 3 }}>
+        {symbol && currentPrice !== null && (
+          <TopCard
+            stockName={symbol}
+            currentPrice={currentPrice}
+            alertPrice={alertPrice ?? 0}
+          />
+        )}
+      </Box>
+
       <Typography variant="h6" gutterBottom>
         Select Symbol and Set Alert
       </Typography>
@@ -59,8 +71,8 @@ const LeftForm = () => {
           onChange={(e) => setSymbol(e.target.value)}
           label="Select Symbol"
         >
-          <MenuItem value="BINANCE:BTCUSDT">BTC USDT</MenuItem>
-          <MenuItem value="BINANCE:ETHUSDT">ETH USDT</MenuItem>
+          <MenuItem value="BINANCE:BTCUSDT">BTC-USDT</MenuItem>
+          <MenuItem value="BINANCE:ETHUSDT">ETH-USDT</MenuItem>
         </Select>
       </FormControl>
 
@@ -94,13 +106,10 @@ const LeftForm = () => {
       </Box>
 
       <Box sx={{ marginTop: 3 }}>
-        <Typography variant="h6">
-          Current Price: {currentPrice ? `$${currentPrice}` : "N/A"}
-        </Typography>
         {alertPrice !== undefined && currentPrice !== null && (
           <Typography color={currentPrice > alertPrice ? "green" : "red"}>
-            The price is {currentPrice > alertPrice ? "above" : "below"} the
-            alert value of ${alertPrice}.
+            The current price is {currentPrice > alertPrice ? "above" : "below"}{" "}
+            the alert value of ${alertPrice}.
           </Typography>
         )}
       </Box>


### PR DESCRIPTION
In this PR, I'm adding the Top Cards feature. One of the API limitations for the Free tier is that it doesn’t recommend interpolating data from different symbols, as the WebSocket can only pull information for one symbol at a time. This means that if we try to open a new WebSocket connection, the first one will no longer be updated, and only one card with the current connection will be displayed.

Another challenge I encountered with this feature is that the Finhub WebSocket doesn’t support the "quote" value to constantly retrieve information on the percentage change of the symbol. The solution I’m proposing is to fetch the endpoint every 5 seconds to update the percentage value in the Top Card.
![image](https://github.com/user-attachments/assets/e7a2836c-0bfb-442c-9c28-849d6411d8f7)
